### PR TITLE
Fix UpdateOrder by user and by admin services, Prevent user password return from schema

### DIFF
--- a/server/src/modules/orders/infra/mongoose/repositories/OrdersRepository.ts
+++ b/server/src/modules/orders/infra/mongoose/repositories/OrdersRepository.ts
@@ -17,10 +17,10 @@ class OrdersRepository {
   }
 
   public async findById(id: string): Promise<IOrder | null> {
-    const order = await Order.findById(id).populate("products").populate('userId');
+    const order = await Order.findById(id).populate("products").populate("userId", "-password");
 
-    if (order)
-      order.userId.password = "";
+    // if (order)
+    //   order.userId.password = "";
 
     return order;
   }
@@ -36,7 +36,7 @@ class OrdersRepository {
     const orders = await Order.find({ userId: user });
 
     for (let i = 0; i < orders.length; i++)
-      await orders[i].populate("products").populate("userId").execPopulate();
+      await orders[i].populate("products").populate("userId", "-password").execPopulate();
 
     return orders;
   }

--- a/server/src/modules/orders/services/Admin/UpdateOrderByAdminService.ts
+++ b/server/src/modules/orders/services/Admin/UpdateOrderByAdminService.ts
@@ -1,5 +1,5 @@
 import { IOrder, IOrderProduct } from '../../infra/mongoose/models/Order';
-import IAddress from '@shared/dtos/IAddressDTO';
+// import IAddress from '@shared/dtos/IAddressDTO';
 
 import AppError from '@shared/errors/AppError';
 import statusCodes from "@config/statusCodes";
@@ -11,6 +11,14 @@ import UsersRepository from '@modules/users/infra/mongoose/repositories/UsersRep
 const ordersRepository = new OrdersRepository();
 const productsRepository = new ProductsRepository();
 const usersRepository = new UsersRepository();
+
+interface IRequestAddress {
+  address?: string;
+  country?: string;
+  state?: string;
+  city?: string;
+  postalCode?: string;
+}
 
 interface IRequestProduct {
   productId: string;
@@ -27,8 +35,8 @@ interface IRequest {
   delivered?: boolean;
   status?: string;
   products?: IRequestProduct[];
-  shippingAddress?: IAddress;
-  billingAddress?: IAddress;
+  shippingAddress?: IRequestAddress;
+  billingAddress?: IRequestAddress;
 }
 
 class UpdateOrderByAdminService {
@@ -40,7 +48,7 @@ class UpdateOrderByAdminService {
     status,
     shippingAddress,
     billingAddress
-  }: IRequest): Promise<IOrder | null> {
+  }: IRequest): Promise<IOrder> {
     const admin = await usersRepository.findById(adminId);
 
     if (!admin)
@@ -131,27 +139,30 @@ class UpdateOrderByAdminService {
     order.status = status ?? order.status;
 
     if (shippingAddress) {
+      const { address, country, state, city, postalCode } = shippingAddress;
 
-      if (!shippingAddress.address && !shippingAddress.country && !shippingAddress.state && !shippingAddress.city && !shippingAddress.postalCode)
+      if (!address && !country && !state && !city && !postalCode)
         throw new AppError("Bad Request.")
 
-      order.shippingAddress.address = shippingAddress.address ?? order.shippingAddress.address;
-      order.shippingAddress.country = shippingAddress.country ?? order.shippingAddress.country;
-      order.shippingAddress.state = shippingAddress.state ?? order.shippingAddress.state;
-      order.shippingAddress.city = shippingAddress.city ?? order.shippingAddress.city;
-      order.shippingAddress.postalCode = shippingAddress.postalCode ?? order.shippingAddress.postalCode;
+      order.shippingAddress.address = address ?? order.shippingAddress.address;
+      order.shippingAddress.country = country ?? order.shippingAddress.country;
+      order.shippingAddress.state = state ?? order.shippingAddress.state;
+      order.shippingAddress.city = city ?? order.shippingAddress.city;
+      order.shippingAddress.postalCode = postalCode ?? order.shippingAddress.postalCode;
     }
 
     if (billingAddress) {
 
-      if (!billingAddress.address && !billingAddress.country && !billingAddress.state && !billingAddress.city && !billingAddress.postalCode)
+      const { address, country, state, city, postalCode } = billingAddress;
+
+      if (!address && !country && !state && !city && !postalCode)
         throw new AppError("Bad Request.")
 
-      order.billingAddress.address = billingAddress.address ?? order.billingAddress.address;
-      order.billingAddress.country = billingAddress.country ?? order.billingAddress.country;
-      order.billingAddress.state = billingAddress.state ?? order.billingAddress.state;
-      order.billingAddress.city = billingAddress.city ?? order.billingAddress.city;
-      order.billingAddress.postalCode = billingAddress.postalCode ?? order.billingAddress.postalCode;
+      order.billingAddress.address = address ?? order.billingAddress.address;
+      order.billingAddress.country = country ?? order.billingAddress.country;
+      order.billingAddress.state = state ?? order.billingAddress.state;
+      order.billingAddress.city = city ?? order.billingAddress.city;
+      order.billingAddress.postalCode = postalCode ?? order.billingAddress.postalCode;
     }
 
     await ordersRepository.save(order);

--- a/server/src/modules/orders/services/Order/GetOrderService.ts
+++ b/server/src/modules/orders/services/Order/GetOrderService.ts
@@ -14,7 +14,7 @@ interface IRequest {
 }
 
 class GetOrderService {
-  public async execute({ userId, orderId }: IRequest): Promise<IOrder | null> {
+  public async execute({ userId, orderId }: IRequest): Promise<IOrder> {
     const user = await usersRepository.findById(userId);
 
     if (!user)
@@ -25,7 +25,7 @@ class GetOrderService {
     if (!order)
       throw new AppError("Order not found.", statusCodes.notFound);
 
-    if (user.permission === "Master" || user.permission === "Admin" || order.userId === user) {
+    if (user.permission === "Master" || user.permission === "Admin" || String(order.userId._id) === userId) {
       return order;
     } else {
       throw new AppError("The user doesn't have access to this order.", statusCodes.forbidden);

--- a/server/src/modules/orders/services/User/UpdateOrderByUserService.ts
+++ b/server/src/modules/orders/services/User/UpdateOrderByUserService.ts
@@ -1,5 +1,5 @@
 import { IOrder, IOrderProduct } from '../../infra/mongoose/models/Order';
-import IAddress from '@shared/dtos/IAddressDTO';
+// import IAddress from '@shared/dtos/IAddressDTO';
 
 import AppError from '@shared/errors/AppError';
 import statusCodes from "@config/statusCodes";
@@ -11,6 +11,14 @@ import UsersRepository from '@modules/users/infra/mongoose/repositories/UsersRep
 const ordersRepository = new OrdersRepository();
 const productsRepository = new ProductsRepository();
 const usersRepository = new UsersRepository();
+
+interface IRequestAddress {
+  address?: string;
+  country?: string;
+  state?: string;
+  city?: string;
+  postalCode?: string;
+}
 
 interface IRequestProduct {
   productId: string;
@@ -25,8 +33,8 @@ interface IRequest {
   userId: string,
   orderId: string,
   products?: IRequestProduct[],
-  shippingAddress?: IAddress,
-  billingAddress?: IAddress,
+  shippingAddress?: IRequestAddress,
+  billingAddress?: IRequestAddress,
 }
 
 class UpdateOrderByUserService {
@@ -36,7 +44,7 @@ class UpdateOrderByUserService {
     products,
     shippingAddress,
     billingAddress
-  }: IRequest): Promise<IOrder | null> {
+  }: IRequest): Promise<IOrder> {
     const user = await usersRepository.findById(userId);
 
     if (!user)
@@ -127,27 +135,30 @@ class UpdateOrderByUserService {
     }
 
     if (shippingAddress) {
+      const { address, country, state, city, postalCode } = shippingAddress;
 
-      if (!shippingAddress.address && !shippingAddress.country && !shippingAddress.state && !shippingAddress.city && !shippingAddress.postalCode)
+      if (!address && !country && !state && !city && !postalCode)
         throw new AppError("Bad Request.")
 
-      order.shippingAddress.address = shippingAddress.address ?? order.shippingAddress.address;
-      order.shippingAddress.country = shippingAddress.country ?? order.shippingAddress.country;
-      order.shippingAddress.state = shippingAddress.state ?? order.shippingAddress.state;
-      order.shippingAddress.city = shippingAddress.city ?? order.shippingAddress.city;
-      order.shippingAddress.postalCode = shippingAddress.postalCode ?? order.shippingAddress.postalCode;
+      order.shippingAddress.address = address ?? order.shippingAddress.address;
+      order.shippingAddress.country = country ?? order.shippingAddress.country;
+      order.shippingAddress.state = state ?? order.shippingAddress.state;
+      order.shippingAddress.city = city ?? order.shippingAddress.city;
+      order.shippingAddress.postalCode = postalCode ?? order.shippingAddress.postalCode;
     }
 
     if (billingAddress) {
 
-      if (!billingAddress.address && !billingAddress.country && !billingAddress.state && !billingAddress.city && !billingAddress.postalCode)
+      const { address, country, state, city, postalCode } = billingAddress;
+
+      if (!address && !country && !state && !city && !postalCode)
         throw new AppError("Bad Request.")
 
-      order.billingAddress.address = billingAddress.address ?? order.billingAddress.address;
-      order.billingAddress.country = billingAddress.country ?? order.billingAddress.country;
-      order.billingAddress.state = billingAddress.state ?? order.billingAddress.state;
-      order.billingAddress.city = billingAddress.city ?? order.billingAddress.city;
-      order.billingAddress.postalCode = billingAddress.postalCode ?? order.billingAddress.postalCode;
+      order.billingAddress.address = address ?? order.billingAddress.address;
+      order.billingAddress.country = country ?? order.billingAddress.country;
+      order.billingAddress.state = state ?? order.billingAddress.state;
+      order.billingAddress.city = city ?? order.billingAddress.city;
+      order.billingAddress.postalCode = postalCode ?? order.billingAddress.postalCode;
     }
 
     // order.shippingAddress = shippingAddress ?? order.shippingAddress;

--- a/server/src/modules/users/infra/http/controllers/ProfileController.ts
+++ b/server/src/modules/users/infra/http/controllers/ProfileController.ts
@@ -13,8 +13,6 @@ class ProfileController {
 
     const user = await showProfile.execute({ userId });
 
-    user.password = '';
-
     return res.status(statusCodes.ok).json(user);
   }
 
@@ -31,8 +29,6 @@ class ProfileController {
       oldPassword,
       password,
     });
-
-    user.password = '';
 
     return res.status(statusCodes.ok).json(user);
   }

--- a/server/src/modules/users/infra/http/controllers/SessionsController.ts
+++ b/server/src/modules/users/infra/http/controllers/SessionsController.ts
@@ -11,8 +11,6 @@ class SessionsController {
 
     const { user, token } = await authenticateUser.execute({ email, password });
 
-    user.password = '';
-
     return res.status(statusCodes.created).json({ user, token });
   }
 }

--- a/server/src/modules/users/infra/http/controllers/UserAvatarController.ts
+++ b/server/src/modules/users/infra/http/controllers/UserAvatarController.ts
@@ -15,8 +15,6 @@ class ProfileController {
       avatarFileName,
     });
 
-    user.password = '';
-
     return res.status(statusCodes.ok).json(user);
   }
 }

--- a/server/src/modules/users/infra/http/controllers/UserPermissionController.ts
+++ b/server/src/modules/users/infra/http/controllers/UserPermissionController.ts
@@ -17,8 +17,6 @@ class UserPermissionController {
       permission
     });
 
-    user.password = '';
-
     return res.status(statusCodes.ok).json(user);
   }
 }

--- a/server/src/modules/users/infra/http/controllers/UserShippingAddressController.ts
+++ b/server/src/modules/users/infra/http/controllers/UserShippingAddressController.ts
@@ -25,8 +25,6 @@ class UserShippingAdressesController {
       main,
     });
 
-    user.password = '';
-
     return res.status(statusCodes.ok).json(user);
   }
 
@@ -45,8 +43,6 @@ class UserShippingAdressesController {
       main,
     });
 
-    user.password = '';
-
     return res.status(statusCodes.ok).json(user);
   }
 
@@ -58,8 +54,6 @@ class UserShippingAdressesController {
       userId,
       postalCode,
     });
-
-    user.password = '';
 
     return res.status(statusCodes.ok).json(user);
   }

--- a/server/src/modules/users/infra/http/controllers/UsersController.ts
+++ b/server/src/modules/users/infra/http/controllers/UsersController.ts
@@ -17,8 +17,6 @@ class UserController {
       password
     });
 
-    user.password = '';
-
     return res.status(statusCodes.created).json(user);
   }
 }

--- a/server/src/modules/users/infra/mongoose/models/User.ts
+++ b/server/src/modules/users/infra/mongoose/models/User.ts
@@ -32,6 +32,7 @@ const UserSchema: Schema = new Schema({
   password: {
     type: String,
     required: true,
+    select: false,
   },
   phone: {
     type: String,

--- a/server/src/modules/users/infra/mongoose/repositories/UsersRepository.ts
+++ b/server/src/modules/users/infra/mongoose/repositories/UsersRepository.ts
@@ -11,7 +11,7 @@ export default class UsersRepository implements IUsersRepository {
   }
 
   public async findByEmail(email: string): Promise<IUser | null> {
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email }).select("+password");
 
     return user;
   }


### PR DESCRIPTION
 On UpdateOrderByAdminService & UpdateOrderByUserService 
- Create a custom interface to make each item optional in the request body.

On User schema
- Remove the password from being returned on every interaction with the user model. (Now, if we need to retrieve the user's password in a find method we need to pass a property called .select("+password))